### PR TITLE
Optimize swap transfers and add maker fees

### DIFF
--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -140,6 +140,7 @@ function swap_with_orderbook(
 ) {
     var to_pay = amount;
     var received = 0L;
+    var total_maker_fee = 0L;
     val order_acc = accounts.ensure_account_without_auth(
         get_order_account_id(pair),
         ACC_TYPE_ORDER
@@ -202,7 +203,7 @@ function swap_with_orderbook(
 
             last_processed += 1;
             val order_to_process = orders[last_processed];
-            val (spent, rec, fully_executed) = utils.spend_on_order(
+            val (spent, rec, maker_fee, fully_executed) = utils.spend_on_order(
                 account,
                 order_to_process,
                 to_pay
@@ -217,7 +218,8 @@ function swap_with_orderbook(
             } else {
                 orders_to_delete.add(order_to_process.id);
             }
-            
+
+            total_maker_fee += maker_fee;
             to_pay -= spent;
             received += rec;
         }
@@ -229,26 +231,35 @@ function swap_with_orderbook(
         safety = to_pay;
     }
 
-    val (amount_to_pay, fee_to_pay) = utils.split_amount_for_fee(
+    val (taker_amount, taker_fee) = utils.split_amount_for_fee(
         true,
         received
     );
 
-    if(amount_to_pay > 0L){
+    if(taker_amount > 0L){
         assets.Unsafe.transfer(
             order_acc,
             account,
             if (buy_cusd) main.cusd.asset else pair.asset1,
-            amount_to_pay 
+            taker_amount 
         ); 
     }
 
-    if(fee_to_pay > 0L){
+    if(taker_fee > 0L){
         assets.Unsafe.transfer(
             order_acc,
             pair.account,
             if (buy_cusd) main.cusd.asset else pair.asset1,
-            fee_to_pay
+            taker_fee
+        );
+    }
+
+    if (total_maker_fee > 0L) {
+        assets.Unsafe.transfer(
+            order_acc,
+            pair.account,
+            if (buy_cusd) pair.asset1 else main.cusd.asset,
+            total_maker_fee 
         );
     }
 

--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -140,8 +140,6 @@ function swap_with_orderbook(
 ) {
     var to_pay = amount;
     var received = 0L;
-    var to_pay_from_order_acc = 0L;
-    var fee_to_pay = 0L;
     val order_acc = accounts.ensure_account_without_auth(
         get_order_account_id(pair),
         ACC_TYPE_ORDER
@@ -204,14 +202,11 @@ function swap_with_orderbook(
 
             last_processed += 1;
             val order_to_process = orders[last_processed];
-            val (spent, rec, fee, fully_executed) = utils.spend_on_order(
+            val (spent, rec, fully_executed) = utils.spend_on_order(
                 account,
                 order_to_process,
                 to_pay
             );
-
-            to_pay_from_order_acc += rec - fee;
-            fee_to_pay += fee;
 
             if (not fully_executed) {
                 require(
@@ -234,12 +229,17 @@ function swap_with_orderbook(
         safety = to_pay;
     }
 
-    if(to_pay_from_order_acc > 0L){
+    val (amount_to_pay, fee_to_pay) = utils.split_amount_for_fee(
+        true,
+        received
+    );
+
+    if(amount_to_pay > 0L){
         assets.Unsafe.transfer(
             order_acc,
             account,
             if (buy_cusd) main.cusd.asset else pair.asset1,
-            to_pay_from_order_acc
+            amount_to_pay 
         ); 
     }
 

--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -140,6 +140,13 @@ function swap_with_orderbook(
 ) {
     var to_pay = amount;
     var received = 0L;
+    var to_pay_from_order_acc = 0L;
+    var fee_to_pay = 0L;
+    val order_acc = accounts.ensure_account_without_auth(
+        get_order_account_id(pair),
+        ACC_TYPE_ORDER
+    );
+
 
     val pair_at_start_struct = pair.to_struct();
 
@@ -197,11 +204,14 @@ function swap_with_orderbook(
 
             last_processed += 1;
             val order_to_process = orders[last_processed];
-            val (spent, rec, fully_executed) = utils.spend_on_order(
+            val (spent, rec, fee, fully_executed) = utils.spend_on_order(
                 account,
                 order_to_process,
                 to_pay
             );
+
+            to_pay_from_order_acc += rec - fee;
+            fee_to_pay += fee;
 
             if (not fully_executed) {
                 require(
@@ -223,6 +233,25 @@ function swap_with_orderbook(
         }
         safety = to_pay;
     }
+
+    if(to_pay_from_order_acc> 0L){
+        assets.Unsafe.transfer(
+            order_acc,
+            account,
+            if (buy_cusd) main.cusd.asset else pair.asset1,
+            to_pay_from_order_acc
+        ); 
+    }
+
+    if(fee_to_pay > 0L){
+        assets.Unsafe.transfer(
+            order_acc,
+            pair.account,
+            if (buy_cusd) main.cusd.asset else pair.asset1,
+            fee_to_pay
+        );
+    }
+
 
     if (received < amount_min) {
         val asset = if (buy_cusd) main.cusd.asset else pair.asset1;

--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -234,7 +234,7 @@ function swap_with_orderbook(
         safety = to_pay;
     }
 
-    if(to_pay_from_order_acc> 0L){
+    if(to_pay_from_order_acc > 0L){
         assets.Unsafe.transfer(
             order_acc,
             account,

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -115,7 +115,7 @@ function spend_on_order(
     accounts.account,
     order_struct: struct<orderbook.order>,
     amount: big_integer
-): (spent:big_integer, received:big_integer, fee: big_integer, fully_executed:boolean) {
+): (spent:big_integer, received:big_integer, fully_executed:boolean) {
     require(amount > 0, "Amount must be greater than 0: " + amount);
     val asset1 = order_struct.pair.asset1;
 
@@ -134,7 +134,6 @@ function spend_on_order(
     }
 
     require(amount > 0, "Output must be greater than 0: " + output);
-    val (remainder, fee) = split_amount_for_fee(true, output);
     
     if (input > 0) {
         assets.Unsafe.transfer(
@@ -153,7 +152,7 @@ function spend_on_order(
         update orderbook.order @ { .id == order_struct.id } ( amount -= output );
     }
     
-    return (spent = input, received = output, fee = fee, fully_executed = fully_executed);
+    return (spent = input, received = output, fully_executed = fully_executed);
 }
 
 function split_amount_for_fee(is_order: boolean, amount: big_integer) {

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -115,7 +115,7 @@ function spend_on_order(
     accounts.account,
     order_struct: struct<orderbook.order>,
     amount: big_integer
-): (spent:big_integer, received:big_integer, fully_executed:boolean) {
+): (spent:big_integer, received:big_integer, fee: big_integer, fully_executed:boolean) {
     require(amount > 0, "Amount must be greater than 0: " + amount);
     val asset1 = order_struct.pair.asset1;
 
@@ -144,22 +144,7 @@ function spend_on_order(
             input
         );
     }
-    if (remainder > 0) {
-        assets.Unsafe.transfer(
-            order_struct.order_acc,
-            account,
-            if (order_struct.buy_cusd) asset1 else main.cusd.asset,
-            remainder,
-        );
-    }
-    if (fee > 0) {
-        assets.Unsafe.transfer(
-            order_struct.order_acc,
-            order_struct.pair.account,
-            if (order_struct.buy_cusd) asset1 else main.cusd.asset,
-            fee,
-        );
-    }
+    
 
     val fully_executed = input == order_worth;
     val fully_spent = input == amount;
@@ -168,7 +153,7 @@ function spend_on_order(
         update orderbook.order @ { .id == order_struct.id } ( amount -= output );
     }
     
-    return (spent = input, received = output, fully_executed = fully_executed);
+    return (spent = input, received = output,fee = fee, fully_executed = fully_executed);
 }
 
 function split_amount_for_fee(is_order: boolean, amount: big_integer) {

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -115,7 +115,7 @@ function spend_on_order(
     accounts.account,
     order_struct: struct<orderbook.order>,
     amount: big_integer
-): (spent:big_integer, received:big_integer, fully_executed:boolean) {
+): (spent:big_integer, received:big_integer, maker_fee:big_integer, fully_executed:boolean) {
     require(amount > 0, "Amount must be greater than 0: " + amount);
     val asset1 = order_struct.pair.asset1;
 
@@ -133,17 +133,18 @@ function spend_on_order(
         output = order_struct.amount;
     }
 
-    require(amount > 0, "Output must be greater than 0: " + output);
+    require(output > 0, "Output must be greater than 0: " + output);
+    val (maker_amount, maker_fee) = split_amount_for_fee(true, output);
     
     if (input > 0) {
         assets.Unsafe.transfer(
             account,
             order_struct.account,
             if (order_struct.buy_cusd) main.cusd.asset else asset1,
-            input
+            maker_amount
         );
     }
-    
+
 
     val fully_executed = input == order_worth;
     val fully_spent = input == amount;
@@ -152,7 +153,7 @@ function spend_on_order(
         update orderbook.order @ { .id == order_struct.id } ( amount -= output );
     }
     
-    return (spent = input, received = output, fully_executed = fully_executed);
+    return (spent = input, received = output, maker_fee = maker_fee, fully_executed = fully_executed);
 }
 
 function split_amount_for_fee(is_order: boolean, amount: big_integer) {

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -153,7 +153,7 @@ function spend_on_order(
         update orderbook.order @ { .id == order_struct.id } ( amount -= output );
     }
     
-    return (spent = input, received = output,fee = fee, fully_executed = fully_executed);
+    return (spent = input, received = output, fee = fee, fully_executed = fully_executed);
 }
 
 function split_amount_for_fee(is_order: boolean, amount: big_integer) {


### PR DESCRIPTION
## Changes
This PR includes two main improvements to the orderbook swap system:

1. Performance Optimization
- Consolidated multiple transfers into a single operation for taker payments
- Moved transfer logic from `spend_on_order` to `swap_with_orderbook` for better batching
- Reduced total number of blockchain operations per swap

2. Maker Fee Implementation
- Added missing maker fee collection from executed orders
- Track and accumulate maker fees across multiple order executions
- Transfer collected maker fees to pair account

## Implementation Details
- Modified `spend_on_order` to return maker fee info instead of handling transfers directly
- Added `total_maker_fee` tracking in `swap_with_orderbook`
- Consolidated transfers into three main operations:
  1. Main swap amount to taker
  2. Taker fee to pair account
  3. Accumulated maker fees to pair account