### PR TITLE
Optimize Storage by Moving Order Account to Pair Entity

### DIFF
--- a/chromia.yml
+++ b/chromia.yml
@@ -34,9 +34,5 @@ compile:
 
 test:
   modules:
-    - test.test_pairs
-    - test.test_swaps
-    - test.test_orders
-    - test.test_admin
     - test.test_performance
   moduleArgs: !include ras.yaml

--- a/chromia.yml
+++ b/chromia.yml
@@ -34,5 +34,9 @@ compile:
 
 test:
   modules:
+    - test.test_pairs
+    - test.test_swaps
+    - test.test_orders
+    - test.test_admin
     - test.test_performance
   moduleArgs: !include ras.yaml

--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -13,7 +13,6 @@ val ACC_TYPE_ORDER = "CHOCCY_ORDER";
 entity order {
     index pairs.pair;
     index accounts.account;
-    order_acc: accounts.account;
     index price: big_integer;
     index buy_cusd: boolean;
     /** if (buy_cusd) amount1 else amount_cusd */
@@ -29,8 +28,8 @@ function get_order_id(accounts.account, pairs.pair, price: big_integer) {
     return (account.id, pair.id, price).hash();
 }
 
-function get_order_account_id(pairs.pair) {
-    return (pair.id, ACC_TYPE_ORDER).hash();
+function get_order_account_id(pairId: byte_array) {
+    return (pairId, ACC_TYPE_ORDER).hash();
 }
 
 function add_order(
@@ -56,7 +55,7 @@ function add_order(
 
     require(condition, "Spot price is better than the order price. Place a spot order instead.");
 
-    val order_acc = utils.ensure_order_account(p);
+    val order_acc = p.order_acc;
 
     // lock the funds
     assets.Unsafe.transfer(
@@ -70,7 +69,6 @@ function add_order(
         get_order_id(account, p, price),
         p,
         account,
-        order_acc,
         price,
         buy_cusd,
         amount,
@@ -81,7 +79,7 @@ function add_order(
 function remove_order(order) {
     // unlock the funds
     assets.Unsafe.transfer(
-            order.order_acc,
+            order.pair.order_acc,
             order.account,
             if (order.buy_cusd) order.pair.asset1 else main.get_cusd(),
             order.amount
@@ -140,7 +138,7 @@ function swap_with_orderbook(
     var received_from_pair = 0L;
     var received_from_orders = 0L;
     var total_maker_fee = 0L;
-    val order_acc = utils.ensure_order_account(pair);
+    val order_acc = pair.order_acc;
 
     val pair_struct = pair.to_struct();
     var amount_1 = if (buy_cusd) pair_struct.amount1 else pair_struct.amount_cusd;

--- a/src/orderbook.rell
+++ b/src/orderbook.rell
@@ -28,8 +28,8 @@ function get_order_id(accounts.account, pairs.pair, price: big_integer) {
     return (account.id, pair.id, price).hash();
 }
 
-function get_order_account_id(pairId: byte_array) {
-    return (pairId, ACC_TYPE_ORDER).hash();
+function get_order_account_id(pair_id: byte_array) {
+    return (pair_id, ACC_TYPE_ORDER).hash();
 }
 
 function add_order(

--- a/src/pairs.rell
+++ b/src/pairs.rell
@@ -13,6 +13,7 @@ entity pair {
     index name;
     index symbol: text;
     key id: byte_array;
+    key order_acc : accounts.account;
 
     asset1: assets.asset;
     mutable amount1: big_integer;
@@ -227,13 +228,13 @@ namespace UNSAFE {
         create pair (
             name = asset1.name.lower_case(),
             symbol = asset1.symbol.lower_case(),
-
             asset1.id,
+            order_acc = utils.ensure_order_account(asset1.id),
+            account = lp_account,
             asset1,
             amount1,
             amount_cusd,
             lp_token = lp,
-            lp_account,
         );
 
         //-1000 to have min liq (uniswapv2 wp)

--- a/src/test/test_operations.rell
+++ b/src/test/test_operations.rell
@@ -66,7 +66,7 @@ operation empty_auth() {
 operation performance_test(account_id: byte_array, pair_id: byte_array, price: big_integer) {
     val trudy = accounts.account @ { account_id };
     val p = pairs.pair @ { pair_id };
-    val order_acc = utils.ensure_order_account(p);
+    val order_acc = p.order_acc;
     assets.Unsafe.mint(
         order_acc,
         p.asset1,
@@ -79,7 +79,6 @@ operation performance_test(account_id: byte_array, pair_id: byte_array, price: b
             x"aa".repeat(i),
             p,
             account = trudy,
-            order_acc,
             price = price - big_integer(i),
             true,
             amount = 1L,

--- a/src/test/test_orders.rell
+++ b/src/test/test_orders.rell
@@ -166,8 +166,8 @@ function test_swaps_use_orders() {
         6676L - 1L + // rounding error
         utils.split_amount_for_fee(true, amount_worth_5k_dollars).fee
     );
-    assert_equals(assets.get_asset_balance(utils.ensure_order_account(p), p.asset1), 0L);
-    assert_equals(assets.get_asset_balance(utils.ensure_order_account(p), main.get_cusd()), 0L);
+    assert_equals(assets.get_asset_balance(p.order_acc, p.asset1), 0L);
+    assert_equals(assets.get_asset_balance(p.order_acc, main.get_cusd()), 0L);
 }
 
 function test_sell_cusd() {
@@ -297,7 +297,7 @@ function test_swaps_with_multiple_orders() {
     );
 
     val o = orderbook.order @ {};
-    assert_equals(o.amount, assets.get_asset_balance(o.order_acc, main.get_cusd()));
+        assert_equals(o.amount, assets.get_asset_balance(o.pair.order_acc, main.get_cusd()));
     assert_equals(o.amount, (amount_worth_6k_dollars / 2L)-5L); // roundings at every swap
 }
 

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -145,9 +145,9 @@ function register_lp(
         "LP provider for asset ID %s on choccyswap".format(asset.id).to_bytes()
     );
 }
-function ensure_order_account(pairId : byte_array) {
+function ensure_order_account(pair_id : byte_array) {
     return accounts.ensure_account_without_auth(
-        orderbook.get_order_account_id(pairId),
+        orderbook.get_order_account_id(pair_id),
         orderbook.ACC_TYPE_ORDER
     );
 }

--- a/src/utils.rell
+++ b/src/utils.rell
@@ -145,10 +145,9 @@ function register_lp(
         "LP provider for asset ID %s on choccyswap".format(asset.id).to_bytes()
     );
 }
-
-function ensure_order_account(pair: pairs.pair) {
+function ensure_order_account(pairId : byte_array) {
     return accounts.ensure_account_without_auth(
-        orderbook.get_order_account_id(pair),
+        orderbook.get_order_account_id(pairId),
         orderbook.ACC_TYPE_ORDER
     );
 }


### PR DESCRIPTION
## refactor: Optimize Storage by Moving Order Account to Pair Entity

Reduces chain storage by storing order account once per pair instead of duplicating it in every order. Order accounts are unique per trading pair, so storing at pair level is more efficient.

Changes:
- Add `order_acc` to Pair entity
- Remove redundant storage from Orders
- Update related functions and tests

All tests passing ✅